### PR TITLE
Update ServerOpcodes for CN 2020.11.17.0000.0000

### DIFF
--- a/UIRes/serveropcode.json
+++ b/UIRes/serveropcode.json
@@ -1,9 +1,9 @@
 {
-  "CfNotifyPop": 678,
+  "CfNotifyPop": 769,
   "CfPreferredRole": 595,
-  "MarketTaxRates": 890,
-  "MarketBoardItemRequestStart": 173,
-  "MarketBoardOfferings": 543,
-  "MarketBoardHistory": 958,
-  "ActorControlSelf": 651,
+  "MarketTaxRates": 105,
+  "MarketBoardItemRequestStart": 465,
+  "MarketBoardOfferings": 676,
+  "MarketBoardHistory": 391,
+  "ActorControlSelf": 688,
 }


### PR DESCRIPTION
CfPreferredRole is not used by Dalamud now.