### PR TITLE
Fix Translation of ProfileCommandsApplySuccess in dalamud_zh.json

### DIFF
--- a/UIRes/loc/dalamud/dalamud_zh.json
+++ b/UIRes/loc/dalamud/dalamud_zh.json
@@ -64,7 +64,7 @@
     "description": "ProfileCommandHandler.<FrameworkOnUpdate>b__8_1"
   },
   "ProfileCommandsApplySuccess": {
-    "message": "合集已启用。",
+    "message": "合集已应用。",
     "description": "ProfileCommandHandler.<FrameworkOnUpdate>b__8_1"
   },
   "PluginProfilesNewProfile": {

--- a/UIRes/loc/dalamud/dalamud_zh.json
+++ b/UIRes/loc/dalamud/dalamud_zh.json
@@ -64,7 +64,7 @@
     "description": "ProfileCommandHandler.<FrameworkOnUpdate>b__8_1"
   },
   "ProfileCommandsApplySuccess": {
-    "message": "合集已应用。",
+    "message": "合集变更已应用。",
     "description": "ProfileCommandHandler.<FrameworkOnUpdate>b__8_1"
   },
   "PluginProfilesNewProfile": {


### PR DESCRIPTION
Using '/xltoggleprofile' to enable or disable a profile will show “合集已启用” despite the actual result. Seems to be a mistranslation. Not very sure whether it will lead to this word.
![218faacca1aa76c8d03670b03b108bc8](https://github.com/user-attachments/assets/02eeb0c7-277c-4e54-9a1f-56aee2d3636d)
